### PR TITLE
use double quotes for crontab

### DIFF
--- a/set_keepalive.sh
+++ b/set_keepalive.sh
@@ -1,4 +1,4 @@
 #! /bin/bash
 
-(echo '*/5 * * * * curl $1 -u "$2"') | crontab -
+(echo "*/5 * * * * curl $1 -u \"$2\"") | crontab -
 service cron start


### PR DESCRIPTION
single quotes aren't parsing the shell args correctly